### PR TITLE
turbolinksの記述を消去

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 


### PR DESCRIPTION
下記のエラーが発生した
ActionView::Template::Error (The asset "application.css" is not present in the asset pipeline.):

エラーを解決するため「 'data-turbolinks-track': 'reload'」を消去した 