### PR TITLE
[Deprecation Notice]エラーによりcapfileに推奨記述を追加した

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,5 +5,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano3/unicorn'
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }


### PR DESCRIPTION
下記コードをcapfileに追記した

require "capistrano/scm/git"
install_plugin Capistrano::SCM::Git