### PR TITLE
SSHKit::Runner::ExecuteErrorのエラー修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,8 +15,7 @@ set :rbenv_type, :user
 set :rbenv_ruby, '2.7.1'
 
 # どの公開鍵を利用してデプロイするか
-set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/myapp.pem']
+# set :ssh_options, auth_methods: ['publickey'], keys: ['~/.ssh/myapp.pem']
 
 # プロセス番号を記載したファイルの場所
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,7 @@
 server '3.115.64.82', user: 'kengo', roles: %w{app db web}
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
-
+set :ssh_options, keys: '~/.ssh/myapp_key_rsa'
 
 
 # role-based syntax


### PR DESCRIPTION
鍵の認証ができないエラーが発生したため、記述を書き換えた